### PR TITLE
Typo selenium python package name.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ pyOpenSSL==19.1.0
 six==1.14.0
 urllib3==1.25.8
 xmltodict==0.12.0
-selinium==3.141.0
+selenium==3.141.0
 beautifulsoup4==4.9.0


### PR DESCRIPTION
A small typo in the package name.