### PR TITLE
Downgrade blinker due to incompatibility with selenium-wire on Rocky9

### DIFF
--- a/rciam_probes.spec
+++ b/rciam_probes.spec
@@ -8,7 +8,7 @@
 Name: rciam_probes
 Summary: RCIAM related probes - Complete
 Group: grnet/rciam
-Version: 2.1.0
+Version: 2.1.1
 Release: %(echo $GIT_COMMIT_DATE).%(echo $GIT_COMMIT_HASH)%{?dist}
 Url: https://github.com/rciam/%{name}
 License: Apache-2.0
@@ -135,6 +135,9 @@ rm -rf $RPM_BUILD_ROOT
 #fi
 
 %changelog
+* Mon Aug 5 2024 Nicolas Liampotis <nliam@grnet.gr> 2.1.1
+- Fixed Python requirements. See https://github.com/seleniumbase/SeleniumBase/issues/2782
+- Updated geckodriver to v0.34.0
 * Wed Jul 3 2024 Nicolas Liampotis <nliam@grnet.gr> 2.1.0
 - Added Python requirements
 * Wed May 29 2024 Nicolas Liampotis <nliam@grnet.gr> 2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 beautifulsoup4==4.10.0
-blinker==1.8.2
+blinker==1.7.0
 brotli==1.1.0
 build==1.2.1
 certifi==2024.2.2

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from codecs import open
 from os import path
 
 __name__ = 'rciam_probes'
-__version__ = '2.1.0'
+__version__ = '2.1.1'
 
 here = path.abspath(path.dirname(__file__))
 


### PR DESCRIPTION
- Versions of blinker >1.7 cause an error: `No module named 'blinker._saferef'` when used with `selenium-wire`.
  As `selenium-wire` is no longer maintained ([selenium-wire repository](https://github.com/wkeeling/selenium-wire)), downgrading blinker to version 1.7.0 is necessary to avoid this issue. For reference, see this related discussion: [SeleniumBase issue #2782](https://github.com/seleniumbase/SeleniumBase/issues/2782).
- Upgrade geckodriver to v0.34.0